### PR TITLE
Add zero-width TAJ watermark with UI toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -308,6 +308,11 @@ h1, h2, h3, h4, h5 {
     border-radius: 12px;
     color: var(--accent-color);
 }
+.watermark-indicator {
+    font-size: 0.8em;
+    color: var(--success-color);
+    margin-left: 6px;
+}
 
 .decode-result {
     margin-bottom: 12px;

--- a/index.html
+++ b/index.html
@@ -98,12 +98,18 @@
             <div v-if="activeTab === 'steganography'" class="tab-content">
                 <div class="transform-layout">
                     <div class="input-section">
-                        <textarea 
-                            id="steg-input" 
-                            v-model="emojiMessage" 
+                        <textarea
+                            id="steg-input"
+                            v-model="emojiMessage"
                             placeholder="Enter text to hide..."
                             @input="autoEncode"
                         ></textarea>
+                        <div class="watermark-option">
+                            <label>
+                                <input type="checkbox" v-model="watermarkEnabled" @change="autoEncode">
+                                Watermark output
+                            </label>
+                        </div>
                     </div>
                     
                     <!-- Emoji Library Section -->
@@ -180,6 +186,7 @@
                             <div class="decoded-message" v-if="universalDecodeResult">
                                 <div class="decode-method">
                                     <span>Decoded using: <strong>{{ universalDecodeResult.method }}</strong></span>
+                                    <span v-if="universalDecodeResult.watermarked" class="watermark-indicator">(watermark verified)</span>
                                     <span v-if="activeTransform && universalDecodeResult.method === activeTransform.name" class="decode-priority">(Priority Match)</span>
                                 </div>
                                 <div class="decode-result">{{ universalDecodeResult.text }}</div>
@@ -812,6 +819,7 @@
                             <div class="decoded-message" v-if="universalDecodeResult">
                                 <div class="decode-method">
                                     <span>Decoded using: <strong>{{ universalDecodeResult.method }}</strong></span>
+                                    <span v-if="universalDecodeResult.watermarked" class="watermark-indicator">(watermark verified)</span>
                                     <span v-if="activeTransform && universalDecodeResult.method === activeTransform.name" class="decode-priority">(Priority Match)</span>
                                 </div>
                                 <div class="decode-result">{{ universalDecodeResult.text }}</div>


### PR DESCRIPTION
## Summary
- Encode TAJ watermark using zero-width characters and strip it during decoding
- Allow watermarking to be toggled from the steganography UI
- Export helpers to verify embedded watermarks and surface status in decoder output

## Testing
- `npm test` *(fails: Missing script "test")*
- `node -e "global.window={};require('./js/steganography.js');window.steganography.setWatermarking(true);let enc=window.steganography.encodeInvisible('hi');console.log('hasWM',window.steganography.verifyWatermark(enc));let decInfo=window.steganography.extractWatermark(enc);console.log('extract',decInfo.watermark);"`


------
https://chatgpt.com/codex/tasks/task_e_68afa1cdcb348323b5922a22d2908cae